### PR TITLE
Add custom plan support (it just changes the default case to return `CUSTOM`)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
 	"author": "Santio71",
 	"license": "ISC",
 	"devDependencies": {
-		"prettier": "^2.7.1"
+		"prettier": "^2.7.1",
+		"ts-node": "^10.9.1"
 	},
 	"dependencies": {
 		"@discordx/importer": "^1.1.10",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
 	"author": "Santio71",
 	"license": "ISC",
 	"devDependencies": {
-		"prettier": "^2.7.1",
-		"ts-node": "^10.9.1"
+		"prettier": "^2.7.1"
 	},
 	"dependencies": {
 		"@discordx/importer": "^1.1.10",

--- a/src/utils/embed.ts
+++ b/src/utils/embed.ts
@@ -25,7 +25,6 @@ export function toEmbed(server: ServerData): EmbedBuilder {
 		startTime = creationDate;
 
 	const serverPlan = getPlan(server);
-
 	return createEmbed(
 		(server.suspended ? `:warning: This server is currently suspended!\n` : '') + description
 	)
@@ -37,8 +36,8 @@ export function toEmbed(server: ServerData): EmbedBuilder {
 				value: embedJoinList(
 					`Server is ${
 						server.suspended
-							? '`suspended` <:no:659939343875702859>'
-							: `${server.online ? '`online`' : '`offline`'} ${
+							? `suspended <:no:659939343875702859>`
+							: `${server.online ? 'online' : 'offline'} ${
 									server.online ? '<:yes:659939181056753665>' : '<:no:659939343875702859>'
 							  }`
 					}`,

--- a/src/utils/embed.ts
+++ b/src/utils/embed.ts
@@ -8,7 +8,7 @@ export function createEmbed(description: string): EmbedBuilder {
 }
 
 export function toEmbed(server: ServerData): EmbedBuilder {
-	var startTime: number | null = Math.floor(server.last_online / 1000);
+	let startTime: number | null = Math.floor(server.last_online / 1000);
 	const creationDate = Math.floor(server.creation / 1000);
 
 	// Don't display the max players if it's a proxy server.
@@ -25,6 +25,7 @@ export function toEmbed(server: ServerData): EmbedBuilder {
 		startTime = creationDate;
 
 	const serverPlan = getPlan(server);
+
 	return createEmbed(
 		(server.suspended ? `:warning: This server is currently suspended!\n` : '') + description
 	)
@@ -36,8 +37,8 @@ export function toEmbed(server: ServerData): EmbedBuilder {
 				value: embedJoinList(
 					`Server is ${
 						server.suspended
-							? `\`suspended\` <:no:659939343875702859>`
-							: `${server.online ? 'online' : 'offline'} ${
+							? '`suspended` <:no:659939343875702859>'
+							: `${server.online ? '`online`' : '`offline`'} ${
 									server.online ? '<:yes:659939181056753665>' : '<:no:659939343875702859>'
 							  }`
 					}`,

--- a/src/utils/embed.ts
+++ b/src/utils/embed.ts
@@ -24,6 +24,7 @@ export function toEmbed(server: ServerData): EmbedBuilder {
 	if (!startTime || isNaN(startTime) || new Date(startTime).getTime() == -1)
 		startTime = creationDate;
 
+	const serverPlan = getPlan(server);
 	return createEmbed(
 		(server.suspended ? `:warning: This server is currently suspended!\n` : '') + description
 	)
@@ -33,8 +34,12 @@ export function toEmbed(server: ServerData): EmbedBuilder {
 			{
 				name: 'Server Status',
 				value: embedJoinList(
-					`Server is \`${server.online ? 'online' : 'offline'}\` ${
-						server.online ? '<:yes:659939181056753665>' : '<:no:659939343875702859>'
+					`Server is ${
+						server.suspended
+							? `\`suspended\` <:no:659939343875702859>`
+							: `${server.online ? 'online' : 'offline'} ${
+									server.online ? '<:yes:659939181056753665>' : '<:no:659939343875702859>'
+							  }`
 					}`,
 					`${server.online ? `Started` : `Last Online`} <t:${startTime}:R>`,
 					`Created <t:${creationDate}:R>`
@@ -44,7 +49,7 @@ export function toEmbed(server: ServerData): EmbedBuilder {
 			{
 				name: 'Server Plan',
 				value: embedJoinList(
-					`The server is using the \`${getPlan(server)} plan\``,
+					`The server is using ${serverPlan === 'CUSTOM' ? 'a' : 'the'} \`${serverPlan}\` plan`,
 					`Price: ${Math.round(server.credits_per_day)} credits/day`,
 					`Icons Unlocked: ${server.purchased_icons.length}`
 				),

--- a/src/utils/minehut.ts
+++ b/src/utils/minehut.ts
@@ -63,11 +63,11 @@ export async function getNetworkStats(): Promise<NetworkStats | null> {
 	return { ...networkData, ...playerData } as NetworkStats;
 }
 
-export type ServerPlan = 'FREE' | 'DAILY' | 'MH20' | 'MH35' | 'MH75' | 'MHUnlimited';
+export type ServerPlan = 'FREE' | 'DAILY' | 'MH20' | 'MH35' | 'MH75' | 'MHUnlimited' | 'CUSTOM';
 
 export function getPlan(server: ServerData): ServerPlan {
 	const data = server.server_plan.split('_');
-	const plan = data.length == 2 ? data[1].toUpperCase() : 'FREE';
+	const plan = data.length == 2 ? data[1].toUpperCase() : data[0];
 
 	switch (plan) {
 		case 'FREE':
@@ -83,7 +83,9 @@ export function getPlan(server: ServerData): ServerPlan {
 		case '10GB':
 			return 'MHUnlimited';
 		default:
-			return 'FREE';
+			return (server.activeServerPlan.startsWith('Custom plan for')
+				? 'CUSTOM'
+				: (server.activeServerPlan as ServerPlan)) || 'FREE';
 	}
 }
 

--- a/src/utils/minehut.ts
+++ b/src/utils/minehut.ts
@@ -83,9 +83,11 @@ export function getPlan(server: ServerData): ServerPlan {
 		case '10GB':
 			return 'MHUnlimited';
 		default:
-			return (server.activeServerPlan.startsWith('Custom plan for')
-				? 'CUSTOM'
-				: (server.activeServerPlan as ServerPlan)) || 'FREE';
+			return (
+				(server.activeServerPlan.startsWith('Custom plan for')
+					? 'CUSTOM'
+					: (server.activeServerPlan as ServerPlan)) || 'FREE'
+			);
 	}
 }
 

--- a/src/utils/minehut.ts
+++ b/src/utils/minehut.ts
@@ -83,7 +83,7 @@ export function getPlan(server: ServerData): ServerPlan {
 		case '10GB':
 			return 'MHUnlimited';
 		default:
-			return server.activeServerPlan.startsWith('Custom plan for') ? 'CUSTOM' : 'FREE';
+			return 'CUSTOM';
 	}
 }
 

--- a/src/utils/minehut.ts
+++ b/src/utils/minehut.ts
@@ -83,11 +83,7 @@ export function getPlan(server: ServerData): ServerPlan {
 		case '10GB':
 			return 'MHUnlimited';
 		default:
-			return (
-				(server.activeServerPlan.startsWith('Custom plan for')
-					? 'CUSTOM'
-					: (server.activeServerPlan as ServerPlan)) || 'FREE'
-			);
+			return server.activeServerPlan.startsWith('Custom plan for') ? 'CUSTOM' : 'FREE';
 	}
 }
 


### PR DESCRIPTION
i did change the embed a bit i made it a bit noticeable that a server is suspended by changing `the server is offline` thing to `the server is suspended` if it is suspended. (to me it looks more noticeable but i don't know about others)

i kept f'ing up on some git stuff that's why there's some weird commits.
i also replaced one `var` to `let` because `let` is better.

I did change online/offline to be in a code block in `Server is online/offline`  but then i thought it looked ugly in a code block so i removed the code block.

also apparently daily plan wasn't detected by `getPlan(ServerData)` so that should be fixed now
![image](https://user-images.githubusercontent.com/76548041/207824366-1c1efd1e-047a-4cbc-8370-5d9c5a51b1ca.png)
^ this is not my server just some random server i found to see if daily worked

you can make edits if you want idc