### PR TITLE
Optional Lockdown Args & Reason

### DIFF
--- a/src/main/kotlin/me/santio/minehututils/commands/impl/LockdownCommand.kt
+++ b/src/main/kotlin/me/santio/minehututils/commands/impl/LockdownCommand.kt
@@ -26,13 +26,15 @@ class LockdownCommand : SlashCommand {
             addSubcommands(
                 Subcommand("channel", "Specify a single channel to modify") {
                     addOptions(
-                        Option<TextChannel>("channel", "The channel to modify", true),
-                        Option<Boolean>("lock", "Whether to lock or unlock the channel", true)
+                        Option<TextChannel>("channel", "The channel to modify", false),
+                        Option<Boolean>("lock", "Whether to lock or unlock the channel", false),
+                        Option<String>("reason", "The reason for locking the channel", false)
                     )
                 },
                 Subcommand("all", "Lock or unlock all channels") {
                     addOptions(
-                        Option<Boolean>("lock", "Whether to lock or unlock all channels", true)
+                        Option<Boolean>("lock", "Whether to lock or unlock all channels", false),
+                        Option<String>("reason", "The reason for locking all channels", false)
                     )
                 }
             )
@@ -40,20 +42,22 @@ class LockdownCommand : SlashCommand {
     }
 
     private suspend fun channel(event: SlashCommandInteractionEvent) {
-        val channel = event.getOption("channel")?.asChannel ?: error("Channel not provided")
-        val lock = event.getOption("lock")?.asBoolean ?: error("Lock not provided")
+        val channel = event.getOption("channel")?.asChannel?.asStandardGuildChannel() ?: event.channel.asTextChannel()
+        val lock = event.getOption("lock")?.asBoolean ?: true
+        val reason = event.getOption("reason")?.asString
         if (!listOf(ChannelType.TEXT, ChannelType.FORUM).contains(channel.type)) error("Channel is not a text channel")
 
-        val locked = Lockdown.isLocked(channel.asStandardGuildChannel())
+        val locked = Lockdown.isLocked(channel)
         if (locked == lock) error("Channel is already ${if (lock) "locked" else "unlocked"}")
 
-        Lockdown.lock(channel.asStandardGuildChannel(), lock)
+        Lockdown.lock(channel, lock, reason)
 
         GuildLogger.of(event.guild!!).log(
             "A channel was ${if (lock) "locked" else "unlocked"} by ${event.user.asMention}",
             ":identification_card: User: ${event.member?.asMention} *(${event.user.name} - ${event.user.id})*",
             ":package: Channel: ${channel.asMention} *(${channel.name} - ${channel.id})*",
-            ":label: Locked: ${if (lock) "Yes" else "No"}"
+            ":label: Locked: ${if (lock) "Yes" else "No"}",
+            ":label: Reason: ${reason?.trim() ?: "No reason provided"}"
         ).withContext(event).titled("Channel Lockdown Changed").post()
 
         event.replyEmbeds(
@@ -62,14 +66,16 @@ class LockdownCommand : SlashCommand {
     }
 
     private suspend fun all(event: SlashCommandInteractionEvent) {
-        val lock = event.getOption("lock")?.asBoolean ?: error("Lock not provided")
+        val lock = event.getOption("lock")?.asBoolean ?: true
+        val reason = event.getOption("reason")?.asString
 
-        Lockdown.lockAll(event.guild!!.id, lock)
+        Lockdown.lockAll(event.guild!!.id, lock, reason)
 
         GuildLogger.of(event.guild!!).log(
             "The server was ${if (lock) "locked" else "unlocked"} by ${event.user.asMention}",
             ":identification_card: User: ${event.member?.asMention} *(${event.user.name} - ${event.user.id})*",
-            ":label: Locked: ${if (lock) "Yes" else "No"}"
+            ":label: Locked: ${if (lock) "Yes" else "No"}",
+            ":label: Reason: ${reason?.trim() ?: "No reason provided"}"
         ).withContext(event).titled("Server Lockdown Changed").post()
 
         event.replyEmbeds(

--- a/src/main/kotlin/me/santio/minehututils/lockdown/Lockdown.kt
+++ b/src/main/kotlin/me/santio/minehututils/lockdown/Lockdown.kt
@@ -88,7 +88,7 @@ object Lockdown: DatabaseHook {
      * @param channel The text channel to lock or unlock
      * @param lock Whether to lock or unlock the channel
      */
-    suspend fun lock(channel: StandardGuildChannel, lock: Boolean) {
+    suspend fun lock(channel: StandardGuildChannel, lock: Boolean, reason: String? = null) {
         val permissions = getPermissionOverride(channel.guild, channel)
 
         if (lock && !permissions.denied.contains(Permission.MESSAGE_SEND)) {
@@ -101,7 +101,11 @@ object Lockdown: DatabaseHook {
             if (channel is TextChannel) {
                 channel.sendMessageEmbeds(
                     EmbedFactory.default(
-                        ":lock: The channel has been locked by a moderator.",
+                        """
+                        :lock: The channel has been locked by a moderator.
+                        
+                        ${reason ?: ""}
+                        """.trim()
                     ).build()
                 ).queue()
             }
@@ -125,12 +129,12 @@ object Lockdown: DatabaseHook {
         }
     }
 
-    suspend fun lockAll(guild: String, lock: Boolean) {
+    suspend fun lockAll(guild: String, lock: Boolean, reason: String? = null) {
         val channels = getLockdownChannels(guild)
 
         for (channel in channels) {
             val channel = bot.getGuildChannelById(channel) ?: continue
-            this.lock(channel as StandardGuildChannel, lock)
+            this.lock(channel as StandardGuildChannel, lock, reason)
         }
     }
 


### PR DESCRIPTION
This PR makes all the arguments in the lockdown commands to be optional. When the channel argument isn't specified, it will use the current channel. And the lock argument is defaulted to true. It also adds a reason argument that Is displayed in the lock embed if it is specified.