### PR TITLE
Prioritize Skript When Searching by Title

### DIFF
--- a/src/main/kotlin/me/santio/minehututils/skript/Skript.kt
+++ b/src/main/kotlin/me/santio/minehututils/skript/Skript.kt
@@ -115,7 +115,8 @@ object Skript {
      * @return The syntax, or null if it doesn't exist
      */
     fun get(title: String): SkriptSyntax? {
-        return syntaxList.find { it.title == title }
+        return syntaxList.find { it.title == title && it.addon == "Skript" }
+            ?: syntaxList.find { it.title == title }
     }
 
     /**


### PR DESCRIPTION
This PR prioritizes Skript when searching by title. This is because there are certain addons on SkriptHub that have a syntax that Skript itself added later. But these addons either haven't removed it or are old. So when a user searches for a syntax by title, it will use the one made by Skript first.