### PR TITLE
Better Silent Tags

### DIFF
--- a/src/main/kotlin/me/santio/minehututils/tags/TagListener.kt
+++ b/src/main/kotlin/me/santio/minehututils/tags/TagListener.kt
@@ -36,11 +36,8 @@ object TagListener: ListenerAdapter() {
         recentlySent.add(id)
 
         try {
-            tag.send(message)
-
-            if (message.flags.contains(MessageFlag.NOTIFICATIONS_SUPPRESSED)) {
-                message.delete().queue()
-            }
+            val silent = message.flags.contains(MessageFlag.NOTIFICATIONS_SUPPRESSED)
+            tag.send(message, silent)
         } catch (e: Exception) {
             e.printStackTrace()
         }


### PR DESCRIPTION
Improves the existing silent tags feature to make it a little better. Before when using a silent tag, the initial user message gets deleted. And since the bot still replies to that message, a "message has been deleted" gets shown by Discord. This PR makes it when a silent tag is used, it sends the tag as a normal message rather than a reply to the original message.