### PR TITLE
Chore: Cleanup user cooldown system and use Kotlin's implementation of the try/catch block

### DIFF
--- a/src/main/kotlin/me/santio/minehututils/cooldown/UserCooldown.kt
+++ b/src/main/kotlin/me/santio/minehututils/cooldown/UserCooldown.kt
@@ -7,8 +7,6 @@ import java.time.Duration
  * @author santio
  */
 data class UserCooldown(
-    val user: String,
-    val kind: Cooldown,
     val started: Long, // 1672531200
     val duration: Long // 84600
 ) {

--- a/src/main/kotlin/me/santio/minehututils/database/models/Tag.kt
+++ b/src/main/kotlin/me/santio/minehututils/database/models/Tag.kt
@@ -75,8 +75,8 @@ data class Tag(
      * @param message The message to send the tag to
      */
     fun send(message: Message) {
-        var lines = body.lines().toMutableList()
-        var buttons = mutableListOf<Button>()
+        val lines = body.lines().toMutableList()
+        val buttons = mutableListOf<Button>()
 
         for (line in body.lines()) {
             if (buttons.size >= 5) break
@@ -103,10 +103,12 @@ data class Tag(
         val lastLine = lines.lastOrNull() ?: return
         var image: URL? = null
 
-        try {
+        kotlin.runCatching {
             image = URI.create(lastLine).toURL()
             lines.remove(lastLine)
-        } catch (e: Exception) {}
+        }.onFailure { result ->
+            result.printStackTrace()
+        }
 
         val reply = message.replyEmbeds(
             EmbedFactory.default(lines.joinToString("\n"))

--- a/src/main/kotlin/me/santio/minehututils/tags/TagListener.kt
+++ b/src/main/kotlin/me/santio/minehututils/tags/TagListener.kt
@@ -35,14 +35,14 @@ object TagListener: ListenerAdapter() {
 
         recentlySent.add(id)
 
-        try {
+        kotlin.runCatching {
             tag.send(message)
 
             if (message.flags.contains(MessageFlag.NOTIFICATIONS_SUPPRESSED)) {
                 message.delete().queue()
             }
-        } catch (e: Exception) {
-            e.printStackTrace()
+        }.onFailure { result ->
+            result.printStackTrace()
         }
 
         coroutineScope.launch(exceptionHandler) {


### PR DESCRIPTION
This pull request transforms the user cooldown system from a MutableSet (Best case O(n) time complexity) to a HashBasedTable (Best case O(1) or static time complexity). Also highlights some possibly unnecessary code in the main handler class.

I swapped the majority of the try/catch blocks with Kotlin's sleeker runCatching utility just for better handling of errors in the future if necessary.

Should work fine I was honestly just bored at 1 AM :p 