### PR TITLE
Change getUserById to retrieveUserById in Marketplace Logging

### DIFF
--- a/src/main/kotlin/me/santio/minehututils/marketplace/MarketplaceListener.kt
+++ b/src/main/kotlin/me/santio/minehututils/marketplace/MarketplaceListener.kt
@@ -26,7 +26,7 @@ object MarketplaceListener : ListenerAdapter() {
         val title = message.title
         val content = message.content
         val postedBy = message.postedBy
-        val postedByUser = bot.getUserById(postedBy)
+        val postedByUser = bot.retrieveUserById(postedBy).complete()
         val type = message.type
         scope.launch {
             val log = GuildLogger.of(channel.guild).log(

--- a/src/main/kotlin/me/santio/minehututils/marketplace/MarketplaceListener.kt
+++ b/src/main/kotlin/me/santio/minehututils/marketplace/MarketplaceListener.kt
@@ -26,9 +26,9 @@ object MarketplaceListener : ListenerAdapter() {
         val title = message.title
         val content = message.content
         val postedBy = message.postedBy
-        val postedByUser = bot.retrieveUserById(postedBy).complete()
         val type = message.type
         scope.launch {
+            val postedByUser = bot.retrieveUserById(postedBy).complete()
             val log = GuildLogger.of(channel.guild).log(
                 """
                     :identification_card: User: ${postedByUser?.asMention} *(${postedByUser?.name} - ${postedByUser?.id})*


### PR DESCRIPTION
Changes getUserById to retrieveUserById when getting the user who posted the message. Before it would display null if the user is not cached. The retrieveUserById method will returned the cached value if its cached and make a request for the user if they are not.