### PR TITLE
Marketplace Log Content to File

### DIFF
--- a/src/main/kotlin/me/santio/minehututils/logger/Log.kt
+++ b/src/main/kotlin/me/santio/minehututils/logger/Log.kt
@@ -9,6 +9,7 @@ import net.dv8tion.jda.api.entities.User
 import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.interactions.Interaction
+import net.dv8tion.jda.api.utils.FileUpload
 import net.dv8tion.jda.api.utils.MarkdownSanitizer
 
 /**
@@ -22,6 +23,7 @@ data class Log(
 
     private var context = ""
     private var title = ""
+    private var fileUpload: FileUpload? = null
 
     /**
      * Attach context to the log, this will be provided at
@@ -83,6 +85,16 @@ data class Log(
     }
 
     /**
+     * Sets a file to upload with the log
+     * @param fileUpload The file upload to attach
+     * @return The log
+     */
+    fun withFile(fileUpload: FileUpload): Log {
+        this.fileUpload = fileUpload
+        return this
+    }
+
+    /**
      * Sets the title of the log
      * @param title The title to set
      * @return The log
@@ -114,7 +126,11 @@ data class Log(
      */
     fun post(): Log {
         if (!guildLogger.isEnabled()) return this
-        guildLogger.channel?.sendMessage(build())?.queue()
+        val message = guildLogger.channel?.sendMessage(build())
+        if (fileUpload != null) {
+            message?.addFiles(fileUpload)
+        }
+        message?.queue()
         return this
     }
 

--- a/src/main/kotlin/me/santio/minehututils/marketplace/MarketplaceListener.kt
+++ b/src/main/kotlin/me/santio/minehututils/marketplace/MarketplaceListener.kt
@@ -8,6 +8,7 @@ import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
 import net.dv8tion.jda.api.events.message.MessageBulkDeleteEvent
 import net.dv8tion.jda.api.events.message.MessageDeleteEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter
+import net.dv8tion.jda.api.utils.FileUpload
 
 object MarketplaceListener : ListenerAdapter() {
 
@@ -34,10 +35,10 @@ object MarketplaceListener : ListenerAdapter() {
                     :identification_card: User: ${postedByUser?.asMention} *(${postedByUser?.name} - ${postedByUser?.id})*
                     :label: Type: $type
                     :name_badge: Title: $title
-                    :newspaper: Post Content:
-                    ${content.take(3500)}
                 """.trimIndent()
-            ).withContext(channel).titled("Marketplace Listing Deleted")
+            ).withContext(channel)
+                .withFile(FileUpload.fromData(content.toByteArray().inputStream(), "listing-$messageId.txt"))
+                .titled("Marketplace Listing Deleted")
 
             if (postedByUser != null) log.withContext(postedByUser)
             log.post()


### PR DESCRIPTION
Rather than logging the marketplace content into the embed directly, this makes it into a file so the log channel doesn't get flooded with a large embed. And staff members can still easily see the content through Discord.