### PR TITLE
Fix Skript by ID Query

### DIFF
--- a/src/main/kotlin/me/santio/minehututils/commands/impl/SkriptCommand.kt
+++ b/src/main/kotlin/me/santio/minehututils/commands/impl/SkriptCommand.kt
@@ -95,7 +95,7 @@ class SkriptCommand : SlashCommand {
         return if (id != null) {
             Skript.search(id)
                 .filter { it.id.toString().startsWith(query) }
-                .map { Command.Choice("[${it.id}] ${it.title}", it.title) }
+                .map { Command.Choice("[${it.id}] ${it.title}", it.id) }
         } else {
             Skript.search(query)
                 .filter { it.title.contains(query, ignoreCase = true) }


### PR DESCRIPTION
This PR fixes searching skript syntax by ID. Before it still mapped the search by the title even when using ID so it didn't work as expected. But this changes it to map by ID.