### PR TITLE
feat: stickied messages

### DIFF
--- a/src/main/kotlin/me/santio/minehututils/MinehutUtils.kt
+++ b/src/main/kotlin/me/santio/minehututils/MinehutUtils.kt
@@ -21,6 +21,7 @@ import me.santio.minehututils.marketplace.MarketplaceManager
 import me.santio.minehututils.minehut.Minehut
 import me.santio.minehututils.resolvers.DurationResolver
 import me.santio.minehututils.skript.Skript
+import me.santio.minehututils.sticky.StickyManager
 import me.santio.minehututils.tags.TagListener
 import me.santio.minehututils.utils.EnvUtils.env
 import net.dv8tion.jda.api.JDA
@@ -94,6 +95,10 @@ suspend fun main() {
 
     timer.schedule(0, 1000 * 60 * 60 * 24) { // 24 hours
         MarketplaceManager.clearOldMessages()
+    }
+
+    timer.schedule(0, 1000 * 5) { // 5 seconds
+        StickyManager.refreshSticky()
     }
 
     // Attach shutdown hooks

--- a/src/main/kotlin/me/santio/minehututils/commands/impl/StickyCommand.kt
+++ b/src/main/kotlin/me/santio/minehututils/commands/impl/StickyCommand.kt
@@ -65,7 +65,7 @@ class StickyCommand : SlashCommand {
                     ).setEphemeral(true).queue()
                     return
                 }
-                StickyManager.start(channel.id, message, event.user.id)
+                StickyManager.start(channel.id, message)
                 event.replyEmbeds(
                     EmbedFactory.success(
                         "Started sticking the message",
@@ -107,7 +107,7 @@ class StickyCommand : SlashCommand {
 
             "set" -> {
                 val message = event.getOption("message")?.asString
-                StickyManager.set(channel.id, message!!, event.user.id)
+                StickyManager.set(channel.id, message!!)
                 event.replyEmbeds(
                     EmbedFactory.success(
                         "Updated the stickied message! sending below...",

--- a/src/main/kotlin/me/santio/minehututils/commands/impl/StickyCommand.kt
+++ b/src/main/kotlin/me/santio/minehututils/commands/impl/StickyCommand.kt
@@ -29,14 +29,13 @@ class StickyCommand : SlashCommand {
                         Option<String>("message", "The message to stick", required = false)
                     )
                 },
-                Subcommand("stop", "Unstick the message") {},
+                Subcommand("stop", "Unstick the message"),
                 Subcommand("set", "Set the stickied message") {
                     addOptions(
                         Option<String>("message", "The message to stick", required = true)
                     )
                 },
-                Subcommand("view", "View the stickied message") {
-                })
+                Subcommand("view", "View the stickied message"))
         }
     }
 
@@ -49,8 +48,8 @@ class StickyCommand : SlashCommand {
                 val message = event.getOption("message")?.asString
                     ?: StickyManager.getMessage(channel.id)
 
-                if (StickyManager.isActive(channel.id)) error("There is already a stickied message in this channel.", true)
-                if (message == null) error("There is not a message to sticky for this channel. Use /sticky start <message> to set a message and start sticking", true)
+                if (StickyManager.isActive(channel.id)) error("There is already a stickied message in this channel.")
+                if (message == null) error("There is not a message to sticky for this channel. Use /sticky start <message> to set a message and start sticking")
                 if (message.length > 4096) error("The message is too long. (max 4096 characters)")
 
                 StickyManager.start(channel.id, message)
@@ -60,7 +59,7 @@ class StickyCommand : SlashCommand {
                         guild
                     ).build()
                 ).setEphemeral(true).queue()
-                GuildLogger.of(event.guild!!).log(
+                GuildLogger.of(guild!!).log(
                     "A sticky was started by ${event.user.asMention}",
                     ":identification_card: User: ${event.member?.asMention} *(${event.user.name} - ${event.user.id})*",
                     ":package: Channel: ${channel.asMention} *(${channel.name} - ${channel.id})*",
@@ -69,7 +68,7 @@ class StickyCommand : SlashCommand {
             }
 
             "stop" -> {
-                if (!StickyManager.isActive(channel.id)) error("There is not a stickied message in this channel.", true)
+                if (!StickyManager.isActive(channel.id)) error("There is not a stickied message in this channel.")
 
                 event.replyEmbeds(
                     EmbedFactory.success(
@@ -88,7 +87,8 @@ class StickyCommand : SlashCommand {
 
             "set" -> {
                 val message = event.getOption("message")?.asString
-                if (message!!.length > 4096) error("The message is too long. (max 4096 characters)")
+                    ?: error("You must provide a message to set")
+                if (message.length > 4096) error("The message is too long. (max 4096 characters)")
 
                 StickyManager.set(channel.id, message)
                 event.replyEmbeds(
@@ -107,7 +107,7 @@ class StickyCommand : SlashCommand {
             }
 
             "view" -> {
-                if (StickyManager.getMessage(channel.id) == null) error("There is not a message to sticky for this channel. Use /sticky start <message> to set a message and start sticking", true)
+                if (StickyManager.getMessage(channel.id) == null) error("There is not a message to sticky for this channel. Use /sticky start <message> to set a message and start sticking")
 
                 event.replyEmbeds(
                     EmbedFactory.success(

--- a/src/main/kotlin/me/santio/minehututils/commands/impl/StickyCommand.kt
+++ b/src/main/kotlin/me/santio/minehututils/commands/impl/StickyCommand.kt
@@ -62,7 +62,7 @@ class StickyCommand : SlashCommand {
         if (message.length > 4096) error("The message is too long. (max 4096 characters)")
 
         StickyManager.start(channel.id, message)
-        StickyManager.forceRefresh(channel.id)
+        StickyManager.refreshSticky(true)
         event.replyEmbeds(
             EmbedFactory.success(
                 "Started sticking the message",
@@ -107,7 +107,7 @@ class StickyCommand : SlashCommand {
         if (message.length > 4096) error("The message is too long. (max 4096 characters)")
 
         StickyManager.set(channel.id, message)
-        StickyManager.forceRefresh(channel.id)
+        StickyManager.refreshSticky(true)
         event.replyEmbeds(
             EmbedFactory.success(
                 "Updated the stickied message!",

--- a/src/main/kotlin/me/santio/minehututils/commands/impl/StickyCommand.kt
+++ b/src/main/kotlin/me/santio/minehututils/commands/impl/StickyCommand.kt
@@ -35,7 +35,8 @@ class StickyCommand : SlashCommand {
                         Option<String>("message", "The message to stick", required = true)
                     )
                 },
-                Subcommand("view", "View the stickied message"))
+                Subcommand("view", "View the stickied message")
+            )
         }
     }
 
@@ -43,7 +44,7 @@ class StickyCommand : SlashCommand {
         val channel = event.channel
         val guild = event.guild
 
-        when (event.subcommandName){
+        when (event.subcommandName) {
             "start" -> {
                 val message = event.getOption("message")?.asString
                     ?: StickyManager.getMessage(channel.id)

--- a/src/main/kotlin/me/santio/minehututils/commands/impl/StickyCommand.kt
+++ b/src/main/kotlin/me/santio/minehututils/commands/impl/StickyCommand.kt
@@ -41,31 +41,35 @@ class StickyCommand : SlashCommand {
                 return
             }
 
-            val currentlyStickied = StickyManager.getStickyChannel(event.guild!!.id)
-            if (currentlyStickied != null) {
-                if (currentlyStickied == channel.id) {
-                    event.replyEmbeds(EmbedFactory.error("There is already a message stickied here", event.guild!!).build())
-                        .setEphemeral(true)
-                        .queue()
-                    return
-                }
-            }
-            
-            StickyManager.stick(event.guild!!.id, channel.id, message, event.user.id)
-            
-            event.replyEmbeds(EmbedFactory.success("Successfully stickied message", event.guild!!).build())
-                .setEphemeral(true)
-                .queue()
-        } else {
-            if (!StickyManager.isStickied(event.guild!!.id)) {
-                event.replyEmbeds(EmbedFactory.error("No message found", event.guild!!).build())
+            if (StickyManager.isStickied(channel.id)) {
+                event.replyEmbeds(
+                    EmbedFactory.error(
+                        "There is already a message stickied here",
+                        event.guild!!
+                    ).build()
+                )
                     .setEphemeral(true)
                     .queue()
                 return
             }
             
-            StickyManager.unstick(event.guild!!.id)
+            StickyManager.stick(channel.id, message, event.user.id)
             
+            event.replyEmbeds(EmbedFactory.success("Successfully stickied message", event.guild!!).build())
+                .setEphemeral(true)
+                .queue()
+        } else {
+            if (!StickyManager.isStickied(channel.id)) {
+                event.replyEmbeds(
+                    EmbedFactory.error("No stickied message found in this channel", event.guild!!).build()
+                )
+                    .setEphemeral(true)
+                    .queue()
+                return
+            }
+
+            StickyManager.unstick(channel.id)
+
             event.replyEmbeds(EmbedFactory.success("Successfully unstuck message", event.guild!!).build())
                 .setEphemeral(true)
                 .queue()

--- a/src/main/kotlin/me/santio/minehututils/commands/impl/StickyCommand.kt
+++ b/src/main/kotlin/me/santio/minehututils/commands/impl/StickyCommand.kt
@@ -41,83 +41,94 @@ class StickyCommand : SlashCommand {
     }
 
     override suspend fun execute(event: SlashCommandInteractionEvent) {
-        val channel = event.channel
-        val guild = event.guild
-
         when (event.subcommandName) {
-            "start" -> {
-                val message = event.getOption("message")?.asString
-                    ?: StickyManager.getMessage(channel.id)
-
-                if (StickyManager.isActive(channel.id)) error("There is already a stickied message in this channel.")
-                if (message == null) error("There is not a message to sticky for this channel. Use /sticky start <message> to set a message and start sticking")
-                if (message.length > 4096) error("The message is too long. (max 4096 characters)")
-
-                StickyManager.start(channel.id, message)
-                event.replyEmbeds(
-                    EmbedFactory.success(
-                        "Started sticking the message",
-                        guild
-                    ).build()
-                ).setEphemeral(true).queue()
-                GuildLogger.of(guild!!).log(
-                    "A sticky was started by ${event.user.asMention}",
-                    ":identification_card: User: ${event.member?.asMention} *(${event.user.name} - ${event.user.id})*",
-                    ":package: Channel: ${channel.asMention} *(${channel.name} - ${channel.id})*",
-                    ":label: Message: " + StickyManager.getMessage(channel.id)
-                ).withContext(event).titled("Sticky Changed").post()
-            }
-
-            "stop" -> {
-                if (!StickyManager.isActive(channel.id)) error("There is not a stickied message in this channel.")
-
-                event.replyEmbeds(
-                    EmbedFactory.success(
-                        "Stopped sticking the message",
-                        guild
-                    ).build()
-                ).setEphemeral(true).queue()
-                StickyManager.stop(channel.id)
-                GuildLogger.of(event.guild!!).log(
-                    "A sticky was stopped by ${event.user.asMention}",
-                    ":identification_card: User: ${event.member?.asMention} *(${event.user.name} - ${event.user.id})*",
-                    ":package: Channel: ${channel.asMention} *(${channel.name} - ${channel.id})*",
-                    ":label: Message: " + StickyManager.getMessage(channel.id)
-                ).withContext(event).titled("Sticky Changed").post()
-            }
-
-            "set" -> {
-                val message = event.getOption("message")?.asString
-                    ?: error("You must provide a message to set")
-                if (message.length > 4096) error("The message is too long. (max 4096 characters)")
-
-                StickyManager.set(channel.id, message)
-                event.replyEmbeds(
-                    EmbedFactory.success(
-                        "Updated the stickied message! Sending below...",
-                        guild
-                    ).build(),
-                    StickyManager.getEmbed(channel.id)
-                ).setEphemeral(true).queue()
-                GuildLogger.of(event.guild!!).log(
-                    "A sticky messaged was updated by ${event.user.asMention}",
-                    ":identification_card: User: ${event.member?.asMention} *(${event.user.name} - ${event.user.id})*",
-                    ":package: Channel: ${channel.asMention} *(${channel.name} - ${channel.id})*",
-                    ":label: Message: " + StickyManager.getMessage(channel.id)
-                ).withContext(event).titled("Sticky Changed").post()
-            }
-
-            "view" -> {
-                if (StickyManager.getMessage(channel.id) == null) error("There is not a message to sticky for this channel. Use /sticky start <message> to set a message and start sticking")
-
-                event.replyEmbeds(
-                    EmbedFactory.success(
-                        "Sending below...",
-                        guild
-                    ).build(),
-                    StickyManager.getEmbed(channel.id)
-                ).setEphemeral(true).queue()
-            }
+            "start" -> start(event)
+            "stop" -> stop(event)
+            "set" -> set(event)
+            "view" -> view(event)
+            else -> error("Subcommand not found")
         }
+    }
+
+    private suspend fun start(event: SlashCommandInteractionEvent) {
+        val channel = event.channel
+        val guild = event.guild!!
+
+        val message = event.getOption("message")?.asString
+            ?: StickyManager.getMessage(channel.id)
+
+        if (StickyManager.isActive(channel.id)) error("There is already a stickied message in this channel.")
+        if (message == null) error("There is not a message to sticky for this channel. Use /sticky start <message> to set a message and start sticking")
+        if (message.length > 4096) error("The message is too long. (max 4096 characters)")
+
+        StickyManager.start(channel.id, message)
+        StickyManager.forceRefresh(channel.id)
+        event.replyEmbeds(
+            EmbedFactory.success(
+                "Started sticking the message",
+                guild
+            ).build()
+        ).setEphemeral(true).queue()
+        GuildLogger.of(guild).log(
+            "A sticky was started by ${event.user.asMention}",
+            ":identification_card: User: ${event.member?.asMention} *(${event.user.name} - ${event.user.id})*",
+            ":package: Channel: ${channel.asMention} *(${channel.name} - ${channel.id})*",
+            ":label: Message: " + StickyManager.getMessage(channel.id)
+        ).withContext(event).titled("Sticky Changed").post()
+    }
+
+    private suspend fun stop(event: SlashCommandInteractionEvent) {
+        val channel = event.channel
+        val guild = event.guild!!
+
+        if (!StickyManager.isActive(channel.id)) error("There is not a stickied message in this channel.")
+
+        event.replyEmbeds(
+            EmbedFactory.success(
+                "Stopped sticking the message",
+                guild
+            ).build()
+        ).setEphemeral(true).queue()
+        StickyManager.stop(channel.id)
+        GuildLogger.of(guild).log(
+            "A sticky was stopped by ${event.user.asMention}",
+            ":identification_card: User: ${event.member?.asMention} *(${event.user.name} - ${event.user.id})*",
+            ":package: Channel: ${channel.asMention} *(${channel.name} - ${channel.id})*",
+            ":label: Message: " + StickyManager.getMessage(channel.id)
+        ).withContext(event).titled("Sticky Changed").post()
+    }
+
+    private suspend fun set(event: SlashCommandInteractionEvent) {
+        val channel = event.channel
+        val guild = event.guild!!
+
+        val message = event.getOption("message")?.asString
+            ?: error("You must provide a message to set")
+        if (message.length > 4096) error("The message is too long. (max 4096 characters)")
+
+        StickyManager.set(channel.id, message)
+        StickyManager.forceRefresh(channel.id)
+        event.replyEmbeds(
+            EmbedFactory.success(
+                "Updated the stickied message!",
+                guild
+            ).build()
+        ).setEphemeral(true).queue()
+        GuildLogger.of(guild).log(
+            "A sticky messaged was updated by ${event.user.asMention}",
+            ":identification_card: User: ${event.member?.asMention} *(${event.user.name} - ${event.user.id})*",
+            ":package: Channel: ${channel.asMention} *(${channel.name} - ${channel.id})*",
+            ":label: Message: " + StickyManager.getMessage(channel.id)
+        ).withContext(event).titled("Sticky Changed").post()
+    }
+
+    private fun view(event: SlashCommandInteractionEvent) {
+        val channel = event.channel
+
+        if (StickyManager.getMessage(channel.id) == null) error("There is not a message to sticky for this channel. Use /sticky start <message> to set a message and start sticking")
+
+        event.replyEmbeds(
+            StickyManager.getEmbed(channel.id)
+        ).setEphemeral(true).queue()
     }
 }

--- a/src/main/kotlin/me/santio/minehututils/commands/impl/StickyCommand.kt
+++ b/src/main/kotlin/me/santio/minehututils/commands/impl/StickyCommand.kt
@@ -6,6 +6,7 @@ import dev.minn.jda.ktx.interactions.commands.Option
 import dev.minn.jda.ktx.interactions.commands.Subcommand
 import me.santio.minehututils.commands.SlashCommand
 import me.santio.minehututils.factories.EmbedFactory
+import me.santio.minehututils.logger.GuildLogger
 import me.santio.minehututils.sticky.StickyManager
 import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
@@ -71,6 +72,12 @@ class StickyCommand : SlashCommand {
                         guild
                     ).build()
                 ).setEphemeral(true).queue()
+                GuildLogger.of(event.guild!!).log(
+                    "A sticky was started by ${event.user.asMention}",
+                    ":identification_card: User: ${event.member?.asMention} *(${event.user.name} - ${event.user.id})*",
+                    ":package: Channel: ${channel.asMention} *(${channel.name} - ${channel.id})*",
+                    ":label: Message: " + StickyManager.getMessage(channel.id)
+                ).withContext(event).titled("Sticky Changed").post()
             }
 
             "stop" -> {
@@ -89,8 +96,13 @@ class StickyCommand : SlashCommand {
                         guild
                     ).build()
                 ).setEphemeral(true).queue()
-
                 StickyManager.stop(channel.id)
+                GuildLogger.of(event.guild!!).log(
+                    "A sticky was stopped by ${event.user.asMention}",
+                    ":identification_card: User: ${event.member?.asMention} *(${event.user.name} - ${event.user.id})*",
+                    ":package: Channel: ${channel.asMention} *(${channel.name} - ${channel.id})*",
+                    ":label: Message: " + StickyManager.getMessage(channel.id)
+                ).withContext(event).titled("Sticky Changed").post()
             }
 
             "set" -> {
@@ -103,6 +115,12 @@ class StickyCommand : SlashCommand {
                     ).build(),
                     StickyManager.getEmbed(channel.id)
                 ).setEphemeral(true).queue()
+                GuildLogger.of(event.guild!!).log(
+                    "A sticky messaged was updated by ${event.user.asMention}",
+                    ":identification_card: User: ${event.member?.asMention} *(${event.user.name} - ${event.user.id})*",
+                    ":package: Channel: ${channel.asMention} *(${channel.name} - ${channel.id})*",
+                    ":label: Message: " + StickyManager.getMessage(channel.id)
+                ).withContext(event).titled("Sticky Changed").post()
             }
 
             "view" -> {

--- a/src/main/kotlin/me/santio/minehututils/commands/impl/StickyCommand.kt
+++ b/src/main/kotlin/me/santio/minehututils/commands/impl/StickyCommand.kt
@@ -1,0 +1,74 @@
+package me.santio.minehututils.commands.impl
+
+import com.google.auto.service.AutoService
+import dev.minn.jda.ktx.interactions.commands.Command
+import dev.minn.jda.ktx.interactions.commands.Option
+import me.santio.minehututils.commands.SlashCommand
+import me.santio.minehututils.factories.EmbedFactory
+import me.santio.minehututils.sticky.StickyManager
+import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import net.dv8tion.jda.api.interactions.InteractionContextType
+import net.dv8tion.jda.api.interactions.commands.DefaultMemberPermissions
+import net.dv8tion.jda.api.interactions.commands.build.CommandData
+
+@AutoService(SlashCommand::class)
+class StickyCommand : SlashCommand {
+
+    override fun getData(): CommandData {
+        return Command("sticky", "Sticky a message") {
+            setContexts(InteractionContextType.GUILD)
+
+            defaultPermissions = DefaultMemberPermissions.enabledFor(Permission.MESSAGE_MANAGE)
+
+            addOptions(
+                Option<Boolean>("stick", "Whether to stick or unstick a message", required = true),
+                Option<String>("message", "The message to stick", required = false)
+            )
+        }
+    }
+
+    override suspend fun execute(event: SlashCommandInteractionEvent) {
+        val stick = event.getOption("stick")?.asBoolean ?: return
+        val message = event.getOption("message")?.asString
+        val channel = event.channel
+        
+        if (stick) {
+            if (message == null) {
+                event.replyEmbeds(EmbedFactory.error("You must provide a message to sticky", event.guild!!).build())
+                    .setEphemeral(true)
+                    .queue()
+                return
+            }
+
+            val currentlyStickied = StickyManager.getStickyChannel(event.guild!!.id)
+            if (currentlyStickied != null) {
+                if (currentlyStickied == channel.id) {
+                    event.replyEmbeds(EmbedFactory.error("There is already a message stickied here", event.guild!!).build())
+                        .setEphemeral(true)
+                        .queue()
+                    return
+                }
+            }
+            
+            StickyManager.stick(event.guild!!.id, channel.id, message, event.user.id)
+            
+            event.replyEmbeds(EmbedFactory.success("Successfully stickied message", event.guild!!).build())
+                .setEphemeral(true)
+                .queue()
+        } else {
+            if (!StickyManager.isStickied(event.guild!!.id)) {
+                event.replyEmbeds(EmbedFactory.error("No message found", event.guild!!).build())
+                    .setEphemeral(true)
+                    .queue()
+                return
+            }
+            
+            StickyManager.unstick(event.guild!!.id)
+            
+            event.replyEmbeds(EmbedFactory.success("Successfully unstuck message", event.guild!!).build())
+                .setEphemeral(true)
+                .queue()
+        }
+    }
+}

--- a/src/main/kotlin/me/santio/minehututils/commands/impl/StickyCommand.kt
+++ b/src/main/kotlin/me/santio/minehututils/commands/impl/StickyCommand.kt
@@ -3,6 +3,7 @@ package me.santio.minehututils.commands.impl
 import com.google.auto.service.AutoService
 import dev.minn.jda.ktx.interactions.commands.Command
 import dev.minn.jda.ktx.interactions.commands.Option
+import dev.minn.jda.ktx.interactions.commands.Subcommand
 import me.santio.minehututils.commands.SlashCommand
 import me.santio.minehututils.factories.EmbedFactory
 import me.santio.minehututils.sticky.StickyManager
@@ -21,58 +22,107 @@ class StickyCommand : SlashCommand {
 
             defaultPermissions = DefaultMemberPermissions.enabledFor(Permission.MESSAGE_MANAGE)
 
-            addOptions(
-                Option<Boolean>("stick", "Whether to stick or unstick a message", required = true),
-                Option<String>("message", "The message to stick", required = false)
-            )
+            addSubcommands(
+                Subcommand("start", "Stick the message") {
+                    addOptions(
+                        Option<String>("message", "The message to stick", required = false)
+                    )
+                },
+                Subcommand("stop", "Unstick the message") {},
+                Subcommand("set", "Set the stickied message") {
+                    addOptions(
+                        Option<String>("message", "The message to stick", required = true)
+                    )
+                },
+                Subcommand("view", "View the stickied message") {
+                })
         }
     }
 
     override suspend fun execute(event: SlashCommandInteractionEvent) {
-        val stick = event.getOption("stick")?.asBoolean ?: return
-        val message = event.getOption("message")?.asString
         val channel = event.channel
-        
-        if (stick) {
-            if (message == null) {
-                event.replyEmbeds(EmbedFactory.error("You must provide a message to sticky", event.guild!!).build())
-                    .setEphemeral(true)
-                    .queue()
-                return
-            }
+        val guild = event.guild
 
-            if (StickyManager.isStickied(channel.id)) {
+        when (event.subcommandName){
+            "start" -> {
+                val message = event.getOption("message")?.asString
+                if (StickyManager.isActive(channel.id)){
+                    event.replyEmbeds(
+                        EmbedFactory.error(
+                            "There is already a stickied message in this channel. Use /sticky set <message> to update it!",
+                            guild
+                        ).build()
+                    ).setEphemeral(true).queue()
+                    return
+                }
+                if (message == null && StickyManager.getMessage(channel.id) == null) {
+                    event.replyEmbeds(
+                        EmbedFactory.error(
+                            "There is not a message to sticky for this channel. Use /sticky start <message> to set a message and start sticking",
+                            guild
+                        ).build()
+                    ).setEphemeral(true).queue()
+                    return
+                }
+                StickyManager.start(channel.id, message, event.user.id)
                 event.replyEmbeds(
-                    EmbedFactory.error(
-                        "There is already a message stickied here",
-                        event.guild!!
+                    EmbedFactory.success(
+                        "Started sticking the message",
+                        guild
                     ).build()
-                )
-                    .setEphemeral(true)
-                    .queue()
-                return
+                ).setEphemeral(true).queue()
             }
-            
-            StickyManager.stick(channel.id, message, event.user.id)
-            
-            event.replyEmbeds(EmbedFactory.success("Successfully stickied message", event.guild!!).build())
-                .setEphemeral(true)
-                .queue()
-        } else {
-            if (!StickyManager.isStickied(channel.id)) {
+
+            "stop" -> {
+                if (!StickyManager.isActive(channel.id)){
+                    event.replyEmbeds(
+                        EmbedFactory.error(
+                            "There is not a stickied message in this channel.",
+                            guild
+                        ).build()
+                    ).setEphemeral(true).queue()
+                    return
+                }
                 event.replyEmbeds(
-                    EmbedFactory.error("No stickied message found in this channel", event.guild!!).build()
-                )
-                    .setEphemeral(true)
-                    .queue()
-                return
+                    EmbedFactory.success(
+                        "Stopped sticking the message",
+                        guild
+                    ).build()
+                ).setEphemeral(true).queue()
+
+                StickyManager.stop(channel.id)
             }
 
-            StickyManager.unstick(channel.id)
+            "set" -> {
+                val message = event.getOption("message")?.asString
+                StickyManager.set(channel.id, message!!, event.user.id)
+                event.replyEmbeds(
+                    EmbedFactory.success(
+                        "Updated the stickied message! sending below...",
+                        guild
+                    ).build(),
+                    StickyManager.getEmbed(channel.id)
+                ).setEphemeral(true).queue()
+            }
 
-            event.replyEmbeds(EmbedFactory.success("Successfully unstuck message", event.guild!!).build())
-                .setEphemeral(true)
-                .queue()
+            "view" -> {
+                if (StickyManager.getMessage(channel.id) == null) {
+                    event.replyEmbeds(
+                        EmbedFactory.error(
+                            "There is not a message to sticky for this channel. Use /sticky start <message> to set a message and start sticking",
+                            guild
+                        ).build()
+                    ).setEphemeral(true).queue()
+                    return
+                }
+                event.replyEmbeds(
+                    EmbedFactory.success(
+                        "sending below...",
+                        guild
+                    ).build(),
+                    StickyManager.getEmbed(channel.id)
+                ).setEphemeral(true).queue()
+            }
         }
     }
 }

--- a/src/main/kotlin/me/santio/minehututils/commands/impl/StickyCommand.kt
+++ b/src/main/kotlin/me/santio/minehututils/commands/impl/StickyCommand.kt
@@ -47,24 +47,12 @@ class StickyCommand : SlashCommand {
         when (event.subcommandName){
             "start" -> {
                 val message = event.getOption("message")?.asString
-                if (StickyManager.isActive(channel.id)){
-                    event.replyEmbeds(
-                        EmbedFactory.error(
-                            "There is already a stickied message in this channel. Use /sticky set <message> to update it!",
-                            guild
-                        ).build()
-                    ).setEphemeral(true).queue()
-                    return
-                }
-                if (message == null && StickyManager.getMessage(channel.id) == null) {
-                    event.replyEmbeds(
-                        EmbedFactory.error(
-                            "There is not a message to sticky for this channel. Use /sticky start <message> to set a message and start sticking",
-                            guild
-                        ).build()
-                    ).setEphemeral(true).queue()
-                    return
-                }
+                    ?: StickyManager.getMessage(channel.id)
+
+                if (StickyManager.isActive(channel.id)) error("There is already a stickied message in this channel.", true)
+                if (message == null) error("There is not a message to sticky for this channel. Use /sticky start <message> to set a message and start sticking", true)
+                if (message.length > 4096) error("The message is too long. (max 4096 characters)")
+
                 StickyManager.start(channel.id, message)
                 event.replyEmbeds(
                     EmbedFactory.success(
@@ -81,15 +69,8 @@ class StickyCommand : SlashCommand {
             }
 
             "stop" -> {
-                if (!StickyManager.isActive(channel.id)){
-                    event.replyEmbeds(
-                        EmbedFactory.error(
-                            "There is not a stickied message in this channel.",
-                            guild
-                        ).build()
-                    ).setEphemeral(true).queue()
-                    return
-                }
+                if (!StickyManager.isActive(channel.id)) error("There is not a stickied message in this channel.", true)
+
                 event.replyEmbeds(
                     EmbedFactory.success(
                         "Stopped sticking the message",
@@ -107,10 +88,12 @@ class StickyCommand : SlashCommand {
 
             "set" -> {
                 val message = event.getOption("message")?.asString
-                StickyManager.set(channel.id, message!!)
+                if (message!!.length > 4096) error("The message is too long. (max 4096 characters)")
+
+                StickyManager.set(channel.id, message)
                 event.replyEmbeds(
                     EmbedFactory.success(
-                        "Updated the stickied message! sending below...",
+                        "Updated the stickied message! Sending below...",
                         guild
                     ).build(),
                     StickyManager.getEmbed(channel.id)
@@ -124,18 +107,11 @@ class StickyCommand : SlashCommand {
             }
 
             "view" -> {
-                if (StickyManager.getMessage(channel.id) == null) {
-                    event.replyEmbeds(
-                        EmbedFactory.error(
-                            "There is not a message to sticky for this channel. Use /sticky start <message> to set a message and start sticking",
-                            guild
-                        ).build()
-                    ).setEphemeral(true).queue()
-                    return
-                }
+                if (StickyManager.getMessage(channel.id) == null) error("There is not a message to sticky for this channel. Use /sticky start <message> to set a message and start sticking", true)
+
                 event.replyEmbeds(
                     EmbedFactory.success(
-                        "sending below...",
+                        "Sending below...",
                         guild
                     ).build(),
                     StickyManager.getEmbed(channel.id)

--- a/src/main/kotlin/me/santio/minehututils/sticky/StickyManager.kt
+++ b/src/main/kotlin/me/santio/minehututils/sticky/StickyManager.kt
@@ -99,6 +99,9 @@ object StickyManager {
         return embed
     }
 
+    /**
+     * Refresh the stickied messages
+     */
     fun refreshSticky() {
         scope.launch {
             stickyMessages.values.forEach { sticky -> try {
@@ -117,7 +120,8 @@ object StickyManager {
 
                     sticky.lastMessageId = embed.id
 
-                } catch (_: Exception) {
+                } catch (e: Exception) {
+                    e.printStackTrace()
                 }
             }
         }

--- a/src/main/kotlin/me/santio/minehututils/sticky/StickyManager.kt
+++ b/src/main/kotlin/me/santio/minehututils/sticky/StickyManager.kt
@@ -1,12 +1,12 @@
 package me.santio.minehututils.sticky
 
 import dev.minn.jda.ktx.coroutines.await
-import dev.minn.jda.ktx.interactions.components.ModalBuilder
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import me.santio.minehututils.bot
 import me.santio.minehututils.factories.EmbedFactory
 import me.santio.minehututils.scope
+import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel
 import java.util.concurrent.ConcurrentHashMap
 
@@ -16,12 +16,13 @@ import java.util.concurrent.ConcurrentHashMap
  * @author ddbrother
  */
 object StickyManager {
-    
+
     data class StickyMessage(
         val channelId: String,
-        val message: String,
+        var message: String,
         val userId: String,
-        var lastMessageId: String? = null
+        var lastMessageId: String? = null,
+        var active: Boolean? = false
     )
 
     private val stickyMessages = ConcurrentHashMap<String, StickyMessage>()
@@ -30,32 +31,51 @@ object StickyManager {
         startLoop()
     }
 
-    /**
-     * Sticks the message in a channel when a user attempts to sticky a message
-     * @param channelId The channel ID
-     * @param message The message to sticky
-     * @param userId The ID of the user attempting to sticky a message
-     */
-    fun stick(channelId: String, message: String, userId: String) {
-        stickyMessages[channelId] = StickyMessage(channelId, message, userId)
+    fun start(channelId: String, message: String?, userId: String) {
+        val sticky = stickyMessages[channelId]
+
+        if (sticky == null) {
+            stickyMessages[channelId] = StickyMessage(
+                channelId = channelId,
+                message = message ?: error("No previous message found. Please provide a message."),
+                userId = userId,
+                active = true
+            )
+        } else {
+            message?.let { sticky.message = it }
+            sticky.active = true
+        }
     }
 
-    /**
-     * Unsticks the message in a channel when a user attempts to unstick a message.
-     * Since there is only one possible message, channelId is sufficient to identify it.
-     * @param channelId The channel ID
-     */
-    fun unstick(channelId: String) {
-        stickyMessages.remove(channelId)
+    fun stop(channelId: String) {
+        stickyMessages[channelId]?.active = false
     }
 
-    /**
-     * Check to see if a stickied message exists for the given channel.
-     * @param channelId The channel ID
-     * @return Whether a stickied message exists for the channel
-     */
-    fun isStickied(channelId: String): Boolean {
-        return stickyMessages.containsKey(channelId)
+    fun set(channelId: String, message: String, userID: String) {
+        val sticky = stickyMessages[channelId]
+        if (sticky == null) {
+            start(channelId, message, userID)
+            stop(channelId)
+        } else {
+            stickyMessages[channelId]?.message = message
+        }
+    }
+
+    fun getMessage(channelId: String): String? {
+        return stickyMessages[channelId]?.message
+    }
+
+    fun isActive(channelId: String): Boolean {
+        return stickyMessages[channelId]?.active == true
+    }
+
+    fun getEmbed(channelId: String): MessageEmbed {
+        val embed = EmbedFactory.default("") {
+            it.setTitle(getMessage(channelId))
+            it.setFooter("This is an automated sticky message.")
+        }.build()
+
+        return embed
     }
 
     private fun startLoop() {
@@ -65,6 +85,7 @@ object StickyManager {
 
                 stickyMessages.values.forEach { sticky ->
                     try {
+                        if (!sticky.active!!) return@forEach
                         val channel = bot.getGuildChannelById(sticky.channelId) as? MessageChannel
                             ?: return@forEach
 

--- a/src/main/kotlin/me/santio/minehututils/sticky/StickyManager.kt
+++ b/src/main/kotlin/me/santio/minehututils/sticky/StickyManager.kt
@@ -3,6 +3,7 @@ package me.santio.minehututils.sticky
 import dev.minn.jda.ktx.coroutines.await
 import kotlinx.coroutines.launch
 import me.santio.minehututils.bot
+import me.santio.minehututils.commands.CommandLoader.logger
 import me.santio.minehututils.factories.EmbedFactory
 import me.santio.minehututils.scope
 import net.dv8tion.jda.api.entities.MessageEmbed
@@ -115,16 +116,22 @@ object StickyManager {
             if (!sticky.active) return@launch
 
             val channel = bot.getGuildChannelById(channelId) as? MessageChannel ?: return@launch
-            try {
-                sticky.lastMessageId?.let {
-                    channel.deleteMessageById(it).await()
+            runCatching {
+                sticky.lastMessageId?.let { id ->
+                    channel.deleteMessageById(id).await()
                 }
-            } catch (e: Exception) {
-                e.printStackTrace()
+            }.onFailure { err ->
+                logger.error("Failed to delete the last sticky message", err)
             }
 
-            val message = channel.sendMessageEmbeds(getEmbed(channelId)).await()
-            sticky.lastMessageId = message.id
+            val embed = runCatching {
+                channel.sendMessageEmbeds(getEmbed(channel.id)).await()
+            }.getOrElse { err ->
+                logger.error("Failed to post sticky message", err)
+                null
+            } ?: return@launch
+            sticky.lastMessageId = embed.id
+
         }
     }
 
@@ -141,16 +148,22 @@ object StickyManager {
                 val lastMessage = channel.history.retrievePast(1).await().firstOrNull()
                 if (lastMessage?.id == sticky.lastMessageId) return@forEach
 
-                try {
-                    sticky.lastMessageId?.let {
-                        channel.deleteMessageById(it).await()
+                runCatching {
+                    sticky.lastMessageId?.let { id ->
+                        channel.deleteMessageById(id).await()
                     }
-                } catch (e: Exception) {
-                    e.printStackTrace()
+                }.onFailure { err ->
+                    logger.error("Failed to delete the last sticky message", err)
                 }
-                val embed = channel.sendMessageEmbeds(getEmbed(channel.id)).await()
 
+                val embed = runCatching {
+                    channel.sendMessageEmbeds(getEmbed(channel.id)).await()
+                }.getOrElse { err ->
+                    logger.error("Failed to post sticky message", err)
+                    null
+                } ?: return@launch
                 sticky.lastMessageId = embed.id
+
             }
         }
     }

--- a/src/main/kotlin/me/santio/minehututils/sticky/StickyManager.kt
+++ b/src/main/kotlin/me/santio/minehututils/sticky/StickyManager.kt
@@ -110,7 +110,8 @@ object StickyManager {
      */
     fun refreshSticky() {
         scope.launch {
-            stickyMessages.values.forEach { sticky -> try {
+            stickyMessages.values.forEach { sticky ->
+                try {
                     if (!sticky.active) return@forEach
                     val channel = bot.getGuildChannelById(sticky.channelId) as? MessageChannel
                         ?: return@forEach

--- a/src/main/kotlin/me/santio/minehututils/sticky/StickyManager.kt
+++ b/src/main/kotlin/me/santio/minehututils/sticky/StickyManager.kt
@@ -1,0 +1,60 @@
+package me.santio.minehututils.sticky
+
+import dev.minn.jda.ktx.coroutines.await
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import me.santio.minehututils.bot
+import me.santio.minehututils.scope
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel
+import java.util.concurrent.ConcurrentHashMap
+
+object StickyManager {
+    
+    data class StickyMessage(
+        val channelId: String,
+        val message: String,
+        val userId: String,
+        var lastMessageId: String? = null
+    )
+
+    private val stickyMessages = ConcurrentHashMap<String, StickyMessage>()
+
+    init {
+        startLoop()
+    }
+
+    fun stick(guildId: String, channelId: String, message: String, userId: String) {
+        stickyMessages[guildId] = StickyMessage(channelId, message, userId)
+    }
+
+    fun unstick(guildId: String) {
+        stickyMessages.remove(guildId)
+    }
+    
+    fun isStickied(guildId: String): Boolean {
+        return stickyMessages.containsKey(guildId)
+    }
+    
+    fun getStickyChannel(guildId: String): String? {
+        return stickyMessages[guildId]?.channelId
+    }
+
+    private fun startLoop() {
+        scope.launch {
+            while (true) {
+                delay(5000)
+                stickyMessages.values.forEach { sticky ->
+                    val channel = bot.getGuildChannelById(sticky.channelId) as? MessageChannel ?: return@forEach
+
+                    if (sticky.lastMessageId != null) {
+                        channel.deleteMessageById(sticky.lastMessageId!!).await()
+                    }
+
+                    val newMsg = channel.sendMessage(sticky.message).await()
+                    sticky.lastMessageId = newMsg.id
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/me/santio/minehututils/sticky/StickyManager.kt
+++ b/src/main/kotlin/me/santio/minehututils/sticky/StickyManager.kt
@@ -8,6 +8,11 @@ import me.santio.minehututils.scope
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel
 import java.util.concurrent.ConcurrentHashMap
 
+/**
+ * The stickied manager for handling stickied messages. By design, there can only be one stickied
+ * message per channel.
+ * @author ddbrother
+ */
 object StickyManager {
     
     data class StickyMessage(
@@ -23,15 +28,30 @@ object StickyManager {
         startLoop()
     }
 
-
+    /**
+     * Sticks the message in a channel when a user attempts to sticky a message
+     * @param channelId The channel ID
+     * @param message The message to sticky
+     * @param userId The ID of the user attempting to sticky a message
+     */
     fun stick(channelId: String, message: String, userId: String) {
         stickyMessages[channelId] = StickyMessage(channelId, message, userId)
     }
 
+    /**
+     * Unsticks the message in a channel when a user attempts to unstick a message.
+     * Since there is only one possible message, channelId is sufficient to identify it.
+     * @param channelId The channel ID
+     */
     fun unstick(channelId: String) {
         stickyMessages.remove(channelId)
     }
 
+    /**
+     * Check to see if a stickied message exists for the given channel.
+     * @param channelId The channel ID
+     * @return Whether a stickied message exists for the channel
+     */
     fun isStickied(channelId: String): Boolean {
         return stickyMessages.containsKey(channelId)
     }

--- a/src/main/kotlin/me/santio/minehututils/sticky/StickyManager.kt
+++ b/src/main/kotlin/me/santio/minehututils/sticky/StickyManager.kt
@@ -8,7 +8,6 @@ import me.santio.minehututils.scope
 import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel
 import java.util.concurrent.ConcurrentHashMap
-import kotlin.concurrent.timer
 
 /**
  * The stickied manager for handling stickied messages. By design, there can only be one stickied

--- a/src/main/kotlin/me/santio/minehututils/sticky/StickyManager.kt
+++ b/src/main/kotlin/me/santio/minehututils/sticky/StickyManager.kt
@@ -1,9 +1,11 @@
 package me.santio.minehututils.sticky
 
 import dev.minn.jda.ktx.coroutines.await
+import dev.minn.jda.ktx.interactions.components.ModalBuilder
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import me.santio.minehututils.bot
+import me.santio.minehututils.factories.EmbedFactory
 import me.santio.minehututils.scope
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel
 import java.util.concurrent.ConcurrentHashMap
@@ -73,9 +75,13 @@ object StickyManager {
                             channel.deleteMessageById(it).await()
                         }
 
-                        val message = sticky.message + "\n-# This is an automated sticky message."
-                        val newMsg = channel.sendMessage(message).await()
-                        sticky.lastMessageId = newMsg.id
+                        val embed = channel.sendMessageEmbeds(EmbedFactory.default("") {
+                            it.setTitle(sticky.message)
+                            it.setFooter("This is an automated sticky message.")
+                        }.build()).await()
+
+                        sticky.lastMessageId = embed.id
+
 
                     } catch (_: Exception) {
                     }

--- a/src/main/kotlin/me/santio/minehututils/sticky/StickyManager.kt
+++ b/src/main/kotlin/me/santio/minehututils/sticky/StickyManager.kt
@@ -1,7 +1,6 @@
 package me.santio.minehututils.sticky
 
 import dev.minn.jda.ktx.coroutines.await
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import me.santio.minehututils.bot
@@ -46,6 +45,9 @@ object StickyManager {
                 delay(5000)
                 stickyMessages.values.forEach { sticky ->
                     val channel = bot.getGuildChannelById(sticky.channelId) as? MessageChannel ?: return@forEach
+
+                    val lastMessage = channel.history.retrievePast(1).await().firstOrNull()
+                    if (lastMessage?.id == sticky.lastMessageId) return@forEach
 
                     if (sticky.lastMessageId != null) {
                         channel.deleteMessageById(sticky.lastMessageId!!).await()

--- a/src/main/kotlin/me/santio/minehututils/sticky/StickyManager.kt
+++ b/src/main/kotlin/me/santio/minehututils/sticky/StickyManager.kt
@@ -19,21 +19,24 @@ object StickyManager {
     data class StickyMessage(
         val channelId: String,
         var message: String,
-        val userId: String,
         var lastMessageId: String? = null,
         var active: Boolean? = false
     )
 
     private val stickyMessages = ConcurrentHashMap<String, StickyMessage>()
 
-    fun start(channelId: String, message: String?, userId: String) {
+    /**
+     * Start stickying a message
+     * @param channelId The id of the channel to sticky
+     * @param message The message to sticky
+     */
+    fun start(channelId: String, message: String?) {
         val sticky = stickyMessages[channelId]
 
         if (sticky == null) {
             stickyMessages[channelId] = StickyMessage(
                 channelId = channelId,
                 message = message ?: error("No previous message found. Please provide a message."),
-                userId = userId,
                 active = true
             )
         } else {
@@ -42,28 +45,52 @@ object StickyManager {
         }
     }
 
+    /**
+     * Stop stickying a message
+     * @param channelId The id of the channel to sticky
+     */
     fun stop(channelId: String) {
         stickyMessages[channelId]?.active = false
     }
 
-    fun set(channelId: String, message: String, userID: String) {
+    /**
+     * Set the sticky message for a channel
+     * @param channelId The id of the channel to sticky
+     * @param message The message to sticky
+     */
+    fun set(channelId: String, message: String) {
         val sticky = stickyMessages[channelId]
         if (sticky == null) {
-            start(channelId, message, userID)
+            start(channelId, message)
             stop(channelId)
         } else {
             stickyMessages[channelId]?.message = message
         }
     }
 
+    /**
+     * Get the sticky message for a channel
+     * @param channelId The id of the channel to sticky
+     * @return The message to sticky
+     */
     fun getMessage(channelId: String): String? {
         return stickyMessages[channelId]?.message
     }
 
+    /**
+     * Get whether a message is being stuck or not
+     * @param channelId The id of the channel to sticky
+     * @return Whether the message is being stuck or not
+     */
     fun isActive(channelId: String): Boolean {
         return stickyMessages[channelId]?.active == true
     }
 
+    /**
+     * Get the embed for a stuck message in a channel
+     * @param channelId The id of the channel to sticky
+     * @return The embed being stuck for the channel
+     */
     fun getEmbed(channelId: String): MessageEmbed {
         val embed = EmbedFactory.default("") {
             it.setTitle(getMessage(channelId))

--- a/src/main/kotlin/me/santio/minehututils/sticky/StickyManager.kt
+++ b/src/main/kotlin/me/santio/minehututils/sticky/StickyManager.kt
@@ -23,20 +23,17 @@ object StickyManager {
         startLoop()
     }
 
-    fun stick(guildId: String, channelId: String, message: String, userId: String) {
-        stickyMessages[guildId] = StickyMessage(channelId, message, userId)
+
+    fun stick(channelId: String, message: String, userId: String) {
+        stickyMessages[channelId] = StickyMessage(channelId, message, userId)
     }
 
-    fun unstick(guildId: String) {
-        stickyMessages.remove(guildId)
+    fun unstick(channelId: String) {
+        stickyMessages.remove(channelId)
     }
-    
-    fun isStickied(guildId: String): Boolean {
-        return stickyMessages.containsKey(guildId)
-    }
-    
-    fun getStickyChannel(guildId: String): String? {
-        return stickyMessages[guildId]?.channelId
+
+    fun isStickied(channelId: String): Boolean {
+        return stickyMessages.containsKey(channelId)
     }
 
     private fun startLoop() {
@@ -44,14 +41,13 @@ object StickyManager {
             while (true) {
                 delay(5000)
                 stickyMessages.values.forEach { sticky ->
-                    val channel = bot.getGuildChannelById(sticky.channelId) as? MessageChannel ?: return@forEach
+                    val channel = bot.getGuildChannelById(sticky.channelId) as? MessageChannel
+                        ?: return@forEach
 
                     val lastMessage = channel.history.retrievePast(1).await().firstOrNull()
                     if (lastMessage?.id == sticky.lastMessageId) return@forEach
 
-                    if (sticky.lastMessageId != null) {
-                        channel.deleteMessageById(sticky.lastMessageId!!).await()
-                    }
+                    sticky.lastMessageId?.let { channel.deleteMessageById(it).await() }
 
                     val newMsg = channel.sendMessage(sticky.message).await()
                     sticky.lastMessageId = newMsg.id

--- a/src/main/kotlin/me/santio/minehututils/sticky/StickyManager.kt
+++ b/src/main/kotlin/me/santio/minehututils/sticky/StickyManager.kt
@@ -60,19 +60,27 @@ object StickyManager {
         scope.launch {
             while (true) {
                 delay(5000)
+
                 stickyMessages.values.forEach { sticky ->
-                    val channel = bot.getGuildChannelById(sticky.channelId) as? MessageChannel
-                        ?: return@forEach
+                    try {
+                        val channel = bot.getGuildChannelById(sticky.channelId) as? MessageChannel
+                            ?: return@forEach
 
-                    val lastMessage = channel.history.retrievePast(1).await().firstOrNull()
-                    if (lastMessage?.id == sticky.lastMessageId) return@forEach
+                        val lastMessage = channel.history.retrievePast(1).await().firstOrNull()
+                        if (lastMessage?.id == sticky.lastMessageId) return@forEach
 
-                    sticky.lastMessageId?.let { channel.deleteMessageById(it).await() }
+                        sticky.lastMessageId?.let {
+                            channel.deleteMessageById(it).await()
+                        }
 
-                    val newMsg = channel.sendMessage(sticky.message).await()
-                    sticky.lastMessageId = newMsg.id
+                        val newMsg = channel.sendMessage(sticky.message).await()
+                        sticky.lastMessageId = newMsg.id
+
+                    } catch (_: Exception) {
+                    }
                 }
             }
         }
     }
+
 }

--- a/src/main/kotlin/me/santio/minehututils/sticky/StickyManager.kt
+++ b/src/main/kotlin/me/santio/minehututils/sticky/StickyManager.kt
@@ -32,7 +32,6 @@ object StickyManager {
      */
     fun start(channelId: String, message: String) {
         val sticky = stickyMessages[channelId]
-
         if (sticky == null) {
             stickyMessages[channelId] = StickyMessage(
                 channelId = channelId,
@@ -40,7 +39,7 @@ object StickyManager {
                 active = true
             )
         } else {
-            message.let { sticky.message = it }
+            sticky.message = message
             sticky.active = true
         }
     }
@@ -61,10 +60,12 @@ object StickyManager {
     fun set(channelId: String, message: String) {
         val sticky = stickyMessages[channelId]
         if (sticky == null) {
-            start(channelId, message)
-            stop(channelId)
+            stickyMessages[channelId] = StickyMessage(
+                channelId = channelId,
+                message = message,
+            )
         } else {
-            stickyMessages[channelId]?.message = message
+            sticky.message = message
         }
     }
 
@@ -106,30 +107,50 @@ object StickyManager {
     }
 
     /**
+     * Force a refresh of a stickied message
+     **/
+    fun forceRefresh(channelId: String) {
+        scope.launch {
+            val sticky = stickyMessages[channelId] ?: return@launch
+            if (!sticky.active) return@launch
+
+            val channel = bot.getGuildChannelById(channelId) as? MessageChannel ?: return@launch
+            try {
+                sticky.lastMessageId?.let {
+                    channel.deleteMessageById(it).await()
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+
+            val message = channel.sendMessageEmbeds(getEmbed(channelId)).await()
+            sticky.lastMessageId = message.id
+        }
+    }
+
+    /**
      * Refresh the stickied messages
      */
     fun refreshSticky() {
         scope.launch {
             stickyMessages.values.forEach { sticky ->
+
+                if (!sticky.active) return@forEach
+                val channel = bot.getGuildChannelById(sticky.channelId) as? MessageChannel ?: return@forEach
+
+                val lastMessage = channel.history.retrievePast(1).await().firstOrNull()
+                if (lastMessage?.id == sticky.lastMessageId) return@forEach
+
                 try {
-                    if (!sticky.active) return@forEach
-                    val channel = bot.getGuildChannelById(sticky.channelId) as? MessageChannel
-                        ?: return@forEach
-
-                    val lastMessage = channel.history.retrievePast(1).await().firstOrNull()
-                    if (lastMessage?.id == sticky.lastMessageId) return@forEach
-
                     sticky.lastMessageId?.let {
                         channel.deleteMessageById(it).await()
                     }
-
-                    val embed = channel.sendMessageEmbeds(getEmbed(channel.id)).await()
-
-                    sticky.lastMessageId = embed.id
-
                 } catch (e: Exception) {
                     e.printStackTrace()
                 }
+                val embed = channel.sendMessageEmbeds(getEmbed(channel.id)).await()
+
+                sticky.lastMessageId = embed.id
             }
         }
     }

--- a/src/main/kotlin/me/santio/minehututils/sticky/StickyManager.kt
+++ b/src/main/kotlin/me/santio/minehututils/sticky/StickyManager.kt
@@ -20,7 +20,7 @@ object StickyManager {
         val channelId: String,
         var message: String,
         var lastMessageId: String? = null,
-        var active: Boolean? = false
+        var active: Boolean = false
     )
 
     private val stickyMessages = ConcurrentHashMap<String, StickyMessage>()
@@ -30,17 +30,17 @@ object StickyManager {
      * @param channelId The id of the channel to sticky
      * @param message The message to sticky
      */
-    fun start(channelId: String, message: String?) {
+    fun start(channelId: String, message: String) {
         val sticky = stickyMessages[channelId]
 
         if (sticky == null) {
             stickyMessages[channelId] = StickyMessage(
                 channelId = channelId,
-                message = message ?: error("No previous message found. Please provide a message."),
+                message = message,
                 active = true
             )
         } else {
-            message?.let { sticky.message = it }
+            message.let { sticky.message = it }
             sticky.active = true
         }
     }
@@ -111,7 +111,7 @@ object StickyManager {
     fun refreshSticky() {
         scope.launch {
             stickyMessages.values.forEach { sticky -> try {
-                    if (!sticky.active!!) return@forEach
+                    if (!sticky.active) return@forEach
                     val channel = bot.getGuildChannelById(sticky.channelId) as? MessageChannel
                         ?: return@forEach
 

--- a/src/main/kotlin/me/santio/minehututils/sticky/StickyManager.kt
+++ b/src/main/kotlin/me/santio/minehututils/sticky/StickyManager.kt
@@ -87,11 +87,17 @@ object StickyManager {
     }
 
     /**
-     * Get the embed for a stuck message in a channel
+     * Get the embed for a stuck message in a channel.
      * @param channelId The id of the channel to sticky
      * @return The embed being stuck for the channel
      */
     fun getEmbed(channelId: String): MessageEmbed {
+        if (getMessage(channelId)?.length!! > 256) {
+            val embed = EmbedFactory.default(getMessage(channelId)!!) {
+                it.setFooter("This is an automated sticky message.")
+            }.build()
+            return embed
+        }
         val embed = EmbedFactory.default("") {
             it.setTitle(getMessage(channelId))
             it.setFooter("This is an automated sticky message.")

--- a/src/main/kotlin/me/santio/minehututils/sticky/StickyManager.kt
+++ b/src/main/kotlin/me/santio/minehututils/sticky/StickyManager.kt
@@ -108,45 +108,20 @@ object StickyManager {
     }
 
     /**
-     * Force a refresh of a stickied message
-     **/
-    fun forceRefresh(channelId: String) {
-        scope.launch {
-            val sticky = stickyMessages[channelId] ?: return@launch
-            if (!sticky.active) return@launch
-
-            val channel = bot.getGuildChannelById(channelId) as? MessageChannel ?: return@launch
-            runCatching {
-                sticky.lastMessageId?.let { id ->
-                    channel.deleteMessageById(id).await()
-                }
-            }.onFailure { err ->
-                logger.error("Failed to delete the last sticky message", err)
-            }
-
-            val embed = runCatching {
-                channel.sendMessageEmbeds(getEmbed(channel.id)).await()
-            }.getOrElse { err ->
-                logger.error("Failed to post sticky message", err)
-                null
-            } ?: return@launch
-            sticky.lastMessageId = embed.id
-
-        }
-    }
-
-    /**
      * Refresh the stickied messages
+     * @param force Whether to force refresh the stickied messages
      */
-    fun refreshSticky() {
+    fun refreshSticky(force: Boolean = false) {
         scope.launch {
             stickyMessages.values.forEach { sticky ->
 
                 if (!sticky.active) return@forEach
                 val channel = bot.getGuildChannelById(sticky.channelId) as? MessageChannel ?: return@forEach
 
-                val lastMessage = channel.history.retrievePast(1).await().firstOrNull()
-                if (lastMessage?.id == sticky.lastMessageId) return@forEach
+                if (!force) {
+                    val lastMessage = channel.history.retrievePast(1).await().firstOrNull()
+                    if (lastMessage?.id == sticky.lastMessageId) return@forEach
+                }
 
                 runCatching {
                     sticky.lastMessageId?.let { id ->
@@ -161,9 +136,9 @@ object StickyManager {
                 }.getOrElse { err ->
                     logger.error("Failed to post sticky message", err)
                     null
-                } ?: return@launch
-                sticky.lastMessageId = embed.id
+                } ?: return@forEach
 
+                sticky.lastMessageId = embed.id
             }
         }
     }

--- a/src/main/kotlin/me/santio/minehututils/sticky/StickyManager.kt
+++ b/src/main/kotlin/me/santio/minehututils/sticky/StickyManager.kt
@@ -73,7 +73,8 @@ object StickyManager {
                             channel.deleteMessageById(it).await()
                         }
 
-                        val newMsg = channel.sendMessage(sticky.message).await()
+                        val message = sticky.message + "\n-# This is an automated sticky message."
+                        val newMsg = channel.sendMessage(message).await()
                         sticky.lastMessageId = newMsg.id
 
                     } catch (_: Exception) {

--- a/src/main/kotlin/me/santio/minehututils/sticky/StickyManager.kt
+++ b/src/main/kotlin/me/santio/minehututils/sticky/StickyManager.kt
@@ -1,7 +1,6 @@
 package me.santio.minehututils.sticky
 
 import dev.minn.jda.ktx.coroutines.await
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import me.santio.minehututils.bot
 import me.santio.minehututils.factories.EmbedFactory
@@ -9,6 +8,7 @@ import me.santio.minehututils.scope
 import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel
 import java.util.concurrent.ConcurrentHashMap
+import kotlin.concurrent.timer
 
 /**
  * The stickied manager for handling stickied messages. By design, there can only be one stickied
@@ -26,10 +26,6 @@ object StickyManager {
     )
 
     private val stickyMessages = ConcurrentHashMap<String, StickyMessage>()
-
-    init {
-        startLoop()
-    }
 
     fun start(channelId: String, message: String?, userId: String) {
         val sticky = stickyMessages[channelId]
@@ -74,41 +70,30 @@ object StickyManager {
             it.setTitle(getMessage(channelId))
             it.setFooter("This is an automated sticky message.")
         }.build()
-
         return embed
     }
 
-    private fun startLoop() {
+    fun refreshSticky() {
         scope.launch {
-            while (true) {
-                delay(5000)
+            stickyMessages.values.forEach { sticky -> try {
+                    if (!sticky.active!!) return@forEach
+                    val channel = bot.getGuildChannelById(sticky.channelId) as? MessageChannel
+                        ?: return@forEach
 
-                stickyMessages.values.forEach { sticky ->
-                    try {
-                        if (!sticky.active!!) return@forEach
-                        val channel = bot.getGuildChannelById(sticky.channelId) as? MessageChannel
-                            ?: return@forEach
+                    val lastMessage = channel.history.retrievePast(1).await().firstOrNull()
+                    if (lastMessage?.id == sticky.lastMessageId) return@forEach
 
-                        val lastMessage = channel.history.retrievePast(1).await().firstOrNull()
-                        if (lastMessage?.id == sticky.lastMessageId) return@forEach
-
-                        sticky.lastMessageId?.let {
-                            channel.deleteMessageById(it).await()
-                        }
-
-                        val embed = channel.sendMessageEmbeds(EmbedFactory.default("") {
-                            it.setTitle(sticky.message)
-                            it.setFooter("This is an automated sticky message.")
-                        }.build()).await()
-
-                        sticky.lastMessageId = embed.id
-
-
-                    } catch (_: Exception) {
+                    sticky.lastMessageId?.let {
+                        channel.deleteMessageById(it).await()
                     }
+
+                    val embed = channel.sendMessageEmbeds(getEmbed(channel.id)).await()
+
+                    sticky.lastMessageId = embed.id
+
+                } catch (_: Exception) {
                 }
             }
         }
     }
-
 }


### PR DESCRIPTION
This PR adds the ability for staff members to sticky messages in order for them to always be visible in channels. It's intended to be used during downtime when the server is not in lockdown, but when a continual message being prompted is helpful. 

[see discord discussion](https://discord.com/channels/1142987286074642474/1455277581824954378)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds stickied messages so staff can keep an info message visible in a channel during downtime. Messages are sent as embeds (title for short text, body for long) with a footer, and managed via the /sticky command.

- **New Features**
  - /sticky subcommands: start (optional message), stop, set (required message), view
  - Requires Manage Messages; guild-only; replies are ephemeral
  - One sticky per channel; supports multiple channels concurrently
  - Background job checks every 5s, deletes the old sticky, and re-posts to keep it at the bottom

<sup>Written for commit eecf09f3995abba89dd60f41ac5e206642a58511. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

