### PR TITLE
Make server command message ephemeral

### DIFF
--- a/src/main/kotlin/me/santio/minehututils/commands/impl/ServerCommand.kt
+++ b/src/main/kotlin/me/santio/minehututils/commands/impl/ServerCommand.kt
@@ -95,11 +95,11 @@ class ServerCommand : SlashCommand {
 
         val guild = event.guild ?: return
         val data = server(serverId) ?: run {
-            event.reply(EmbedFactory.error("Failed to find the server", guild)).queue()
+            event.reply(EmbedFactory.error("Failed to find the server", guild)).setEphemeral(true).queue()
             return
         }
 
-        event.reply(buildServerEmbed(guild, data)).queue()
+        event.reply(buildServerEmbed(guild, data)).setEphemeral(true).queue()
     }
 
 }


### PR DESCRIPTION
Change the server embed message to be ephemeral, preventing the issue of "advertising" in the botcmds channel

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make /server command replies ephemeral so results and errors are only visible to the requester, preventing public “advertising” in bot channels.

- **Bug Fixes**
  - Added `.setEphemeral(true)` to both success and error replies in `ServerCommand`.

<sup>Written for commit 044fcba482999f9ecbd713ebe84ae8692321028d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SantioMC/MinehutUtils/pull/73?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

